### PR TITLE
Add GitHub Actions workflow for compilation and release

### DIFF
--- a/.github/workflows/compile-release.yml
+++ b/.github/workflows/compile-release.yml
@@ -1,0 +1,61 @@
+# This GitHub Actions workflow compiles the code for several architectures and
+# generates a release on GitHub
+
+name: Compile and Release
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Compile for different operating systems and release
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      # Dudu requires Go version 1.16+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16.0'
+
+      - name: Setup
+        run: |
+          mkdir -p bin
+
+      - name: Compile for Windows
+        run: |
+          GOOS=windows GOARCH=386 go build -o bin/dudu-windows_x86.exe github.com/lsnow99/dudu/cmd/dudu
+          GOOS=windows GOARCH=amd64 go build -o bin/dudu-windows_x64.exe github.com/lsnow99/dudu/cmd/dudu
+
+      - name: Compile for OS X
+        run: |
+          GOOS=darwin GOARCH=amd64 go build -o bin/dudu-osx_amd64 github.com/lsnow99/dudu/cmd/dudu
+          GOOS=darwin GOARCH=arm64 go build -o bin/dudu-osx_arm64 github.com/lsnow99/dudu/cmd/dudu
+
+      - name: Compile for Linux
+        run: |
+          GOOS=linux GOARCH=386 go build -o bin/dudu-linux_x86 github.com/lsnow99/dudu/cmd/dudu
+          GOOS=linux GOARCH=amd64 go build -o bin/dudu-linux_x64 github.com/lsnow99/dudu/cmd/dudu
+          GOOS=linux GOARCH=arm go build -o bin/dudu-linux_arm github.com/lsnow99/dudu/cmd/dudu
+          GOOS=linux GOARCH=arm64 go build -o bin/dudu-linux_arm64 github.com/lsnow99/dudu/cmd/dudu
+
+      # Requires adding a GITHUB_TOKEN secret
+      - name: Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd bin
+
+          TAG="$(git describe --tags)"
+
+          ASSETS=()
+          for ASSET in *; do
+            ASSETS+=("--attach" "$ASSET")
+          done
+
+          hub release create \
+            "${ASSETS[@]}" \
+            --message "Compiled binaries for dudu $TAG" \
+            "$TAG"

--- a/.github/workflows/compile-release.yml
+++ b/.github/workflows/compile-release.yml
@@ -26,20 +26,20 @@ jobs:
 
       - name: Compile for Windows
         run: |
-          GOOS=windows GOARCH=386 go build -o bin/dudu-windows_x86.exe github.com/lsnow99/dudu/cmd/dudu
-          GOOS=windows GOARCH=amd64 go build -o bin/dudu-windows_x64.exe github.com/lsnow99/dudu/cmd/dudu
+          GOOS=windows GOARCH=386 go build -o bin/dudu-windows_x86.exe -ldflags="-X 'main.Version=$(git describe --tags)'" github.com/lsnow99/dudu/cmd/dudu
+          GOOS=windows GOARCH=amd64 go build -o bin/dudu-windows_x64.exe -ldflags="-X 'main.Version=$(git describe --tags)'" github.com/lsnow99/dudu/cmd/dudu
 
       - name: Compile for OS X
         run: |
-          GOOS=darwin GOARCH=amd64 go build -o bin/dudu-osx_amd64 github.com/lsnow99/dudu/cmd/dudu
-          GOOS=darwin GOARCH=arm64 go build -o bin/dudu-osx_arm64 github.com/lsnow99/dudu/cmd/dudu
+          GOOS=darwin GOARCH=amd64 go build -o bin/dudu-osx_amd64 -ldflags="-X 'main.Version=$(git describe --tags)'" github.com/lsnow99/dudu/cmd/dudu
+          GOOS=darwin GOARCH=arm64 go build -o bin/dudu-osx_arm64 -ldflags="-X 'main.Version=$(git describe --tags)'" github.com/lsnow99/dudu/cmd/dudu
 
       - name: Compile for Linux
         run: |
-          GOOS=linux GOARCH=386 go build -o bin/dudu-linux_x86 github.com/lsnow99/dudu/cmd/dudu
-          GOOS=linux GOARCH=amd64 go build -o bin/dudu-linux_x64 github.com/lsnow99/dudu/cmd/dudu
-          GOOS=linux GOARCH=arm go build -o bin/dudu-linux_arm github.com/lsnow99/dudu/cmd/dudu
-          GOOS=linux GOARCH=arm64 go build -o bin/dudu-linux_arm64 github.com/lsnow99/dudu/cmd/dudu
+          GOOS=linux GOARCH=386 go build -o bin/dudu-linux_x86 -ldflags="-X 'main.Version=$(git describe --tags)'" github.com/lsnow99/dudu/cmd/dudu
+          GOOS=linux GOARCH=amd64 go build -o bin/dudu-linux_x64 -ldflags="-X 'main.Version=$(git describe --tags)'" github.com/lsnow99/dudu/cmd/dudu
+          GOOS=linux GOARCH=arm go build -o bin/dudu-linux_arm -ldflags="-X 'main.Version=$(git describe --tags)'" github.com/lsnow99/dudu/cmd/dudu
+          GOOS=linux GOARCH=arm64 go build -o bin/dudu-linux_arm64 -ldflags="-X 'main.Version=$(git describe --tags)'" github.com/lsnow99/dudu/cmd/dudu
 
       # Requires adding a GITHUB_TOKEN secret
       - name: Create GitHub release

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This package uses the `embed` package, which is only available in Go version 1.1
 - `go install github.com/lsnow99/dudu/cmd/dudu@latest`
 
 ### Installation from source
-- `git clone github.com/lsnow99/dudu`
+- `git clone https://github.com/lsnow99/dudu`
 - `go build -o dudu cmd/dudu`
 - `mv dudu $GOBIN`
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Oh, did you mean why the name? No reason, just thought it sounded cool.
 ## Getting Started
 
 First, consider why you are using this obscure and opinionated static site generator when so many objectively better alternatives exist.
+
+This package uses the `embed` package, which is only available in Go version 1.16 and higher.
 ### Installation (using `go install`)
 - `go install github.com/lsnow99/dudu/cmd/dudu@latest`
 


### PR DESCRIPTION
Added this workflow. Will need a `GITHUB_TOKEN` secret in order to publish the release. Even then, it might require some debugging if there are collisions with the Git tag names.